### PR TITLE
Adding pagination to creature list view

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -403,3 +403,57 @@
     width: 100%;
   }
 }
+
+/* Pagination Styles */
+.pagination-info {
+  text-align: center;
+  margin: 16px 0;
+  color: #5d4037;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 24px;
+  padding: 16px;
+  background: linear-gradient(135deg, rgba(255, 248, 225, 0.5) 0%, rgba(255, 243, 224, 0.5) 100%);
+  border-radius: 12px;
+}
+
+.page-numbers {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-page {
+  min-width: 40px;
+  padding: 8px 12px;
+  background: linear-gradient(135deg, #fff8e1 0%, #fff3e0 100%);
+  color: #5d4037;
+  border: 2px solid #d7ccc8;
+  font-size: 14px;
+}
+
+.btn-page:hover:not(:disabled) {
+  background: linear-gradient(135deg, #ffecb3 0%, #ffe0b2 100%);
+  border-color: #bcaaa4;
+}
+
+.btn-page.active {
+  background: linear-gradient(135deg, #8d6e63 0%, #6d4c41 100%);
+  color: white;
+  border-color: #5d4037;
+  font-weight: 700;
+}
+
+.btn-page.active:hover {
+  background: linear-gradient(135deg, #8d6e63 0%, #6d4c41 100%);
+}
+
+.pagination .btn-secondary {
+  min-width: 100px;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,8 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [toast, setToast] = useState(null);
   const [selectedSpecies, setSelectedSpecies] = useState(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const creaturesPerPage = 8;
 
   const showToast = (message, type = "success") => {
     setToast({ message, type });
@@ -21,6 +23,7 @@ function App() {
   const handleGetAllCreatures = async () => {
     setLoading(true);
     setSelectedCreature(null);
+    setCurrentPage(1); // Reset to first page when loading new data
     try {
       const data = await api.getAllCreatures();
       setCreatures(data);
@@ -30,6 +33,28 @@ function App() {
     } finally {
       setLoading(false);
     }
+  };
+
+  // Pagination calculations
+  const indexOfLastCreature = currentPage * creaturesPerPage;
+  const indexOfFirstCreature = indexOfLastCreature - creaturesPerPage;
+  const currentCreatures = creatures.slice(indexOfFirstCreature, indexOfLastCreature);
+  const totalPages = Math.ceil(creatures.length / creaturesPerPage);
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const handlePageClick = (pageNumber) => {
+    setCurrentPage(pageNumber);
   };
 
   const handleGetById = async () => {
@@ -120,16 +145,54 @@ function App() {
           </button>
 
           {creatures.length > 0 && (
-            <div className="creatures-list">
-              {creatures.map((creature) => (
-                <div key={creature.id} className="creature-card">
-                  <h3>{creature.name}</h3>
-                  <p><strong>Species:</strong> {creature.species}</p>
-                  <p><strong>ID:</strong> {creature.id}</p>
-                  <p><strong>Created:</strong> {new Date(creature.createdAt).toLocaleString()}</p>
+            <>
+              <div className="pagination-info">
+                Showing {indexOfFirstCreature + 1}-{Math.min(indexOfLastCreature, creatures.length)} of {creatures.length} creatures
+              </div>
+
+              <div className="creatures-list">
+                {currentCreatures.map((creature) => (
+                  <div key={creature.id} className="creature-card">
+                    <h3>{creature.name}</h3>
+                    <p><strong>Species:</strong> {creature.species}</p>
+                    <p><strong>ID:</strong> {creature.id}</p>
+                    <p><strong>Created:</strong> {new Date(creature.createdAt).toLocaleString()}</p>
+                  </div>
+                ))}
+              </div>
+
+              {totalPages > 1 && (
+                <div className="pagination">
+                  <button
+                    onClick={handlePrevPage}
+                    disabled={currentPage === 1}
+                    className="btn btn-secondary"
+                  >
+                    ← Previous
+                  </button>
+
+                  <div className="page-numbers">
+                    {Array.from({ length: totalPages }, (_, i) => i + 1).map((pageNum) => (
+                      <button
+                        key={pageNum}
+                        onClick={() => handlePageClick(pageNum)}
+                        className={`btn btn-page ${currentPage === pageNum ? 'active' : ''}`}
+                      >
+                        {pageNum}
+                      </button>
+                    ))}
+                  </div>
+
+                  <button
+                    onClick={handleNextPage}
+                    disabled={currentPage === totalPages}
+                    className="btn btn-secondary"
+                  >
+                    Next →
+                  </button>
                 </div>
-              ))}
-            </div>
+              )}
+            </>
           )}
         </section>
 


### PR DESCRIPTION
This pull request introduces pagination to the creatures list in the frontend, improving usability for users when browsing large numbers of creatures. The changes include new state management and logic in `App.jsx` to handle pagination, updates to the rendering to show only the current page of creatures, and new styles in `App.css` for the pagination controls.

**Pagination functionality:**

* Added pagination state (`currentPage`, `creaturesPerPage`) and logic for calculating which creatures to display, as well as handlers for navigating between pages (`handleNextPage`, `handlePrevPage`, `handlePageClick`) in `App.jsx`. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R16-R17) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R38-R59)
* Updated the creatures list rendering to display only the current page of creatures, and added a summary showing which creatures are currently being viewed.

**Pagination UI:**

* Added pagination controls (Previous/Next buttons and page number buttons) to the UI, with appropriate disabling and highlighting logic.
* Added new CSS styles for pagination controls and info in `App.css` to improve appearance and usability.

**User experience improvements:**

* Reset pagination to the first page whenever a new set of creatures is loaded.