### PR TITLE
Add biome viewset with health check and soft delete support

### DIFF
--- a/biome-service/biomes/serializers.py
+++ b/biome-service/biomes/serializers.py
@@ -13,11 +13,14 @@ class BiomeSerializer(serializers.ModelSerializer):
 
         if len(value) < 3:
             raise serializers.ValidationError("Name must be at least 3 characters.")
-        if len(value) > 25:
-            raise serializers.ValidationError("Name cannot be more than 25 characters.")
+        if len(value) > 50:
+            raise serializers.ValidationError("Name cannot be more than 50 characters.")
         if not value[0].isalpha():
             raise serializers.ValidationError("Name must start with a letter.")
-        if Biome.objects.filter(name__iexact=value).exists():
+        existing = Biome.objects.filter(name__iexact=value)
+        if self.instance:
+            existing = existing.exclude(pk=self.instance.pk)
+        if existing.exists():
             raise serializers.ValidationError("A biome with this name already exists.")
 
         return value

--- a/biome-service/biomes/views.py
+++ b/biome-service/biomes/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+from rest_framework import viewsets, status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from .models import Biome
+from .serializers import BiomeSerializer
 
-# Create your views here.
+
+@api_view(["GET"])
+def health_check(request):
+    return Response({"status": "ok"})
+
+
+class BiomeViewSet(viewsets.ModelViewSet):
+    serializer_class = BiomeSerializer
+    # Exclude PUT — callers should use PATCH for partial updates
+    http_method_names = ["get", "post", "patch", "delete", "head", "options"]
+
+    def get_queryset(self):
+        include_inactive = self.request.query_params.get("include_inactive", "false").lower() == "true"
+        queryset = Biome.objects.all()
+
+        if not include_inactive:
+            queryset = queryset.filter(is_active=True)
+        return queryset
+
+    def destroy(self, request, *args, **kwargs):
+        biome = self.get_object()
+
+        if request.query_params.get("unlink_creatures", "false").lower() == "true":
+            # TODO (M3+): call the creature-service API here to PATCH all creatures
+            # with biome_id == biome.pk, setting biome_id to null.
+            # This is intentionally a no-op until the creature <-> biome FK exists.
+            pass
+
+        biome.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Introduce a new viewset for managing biomes, including a health check endpoint and support for soft deletion of biomes. The validation for biome names has been updated to allow longer names and ensure uniqueness, considering the instance being updated.

Close #15 #16 #17